### PR TITLE
Validate Waypoint trajectory segment and report error messages

### DIFF
--- a/arduino/hello_stepper/Common.h
+++ b/arduino/hello_stepper/Common.h
@@ -200,6 +200,7 @@ struct __attribute__ ((packed)) TrajectorySegment{
 
 struct __attribute__ ((packed)) TrajectorySegmentReply{
   uint8_t success;
+  char error_message[100];
 };
 
 /////////////////////////////////////////////////////////////////

--- a/arduino/hello_stepper/HelloController.cpp
+++ b/arduino/hello_stepper/HelloController.cpp
@@ -279,7 +279,8 @@ void handleNewRPC()
     case RPC_SET_NEXT_TRAJECTORY_SEG: 
           memcpy(&traj_seg_in, rpc_in+1, sizeof(TrajectorySegment)); //copy in the new segment
           traj_seg_reply.success=trajectory_manager.set_next_trajectory_segment(&traj_seg_in, motion_limits_set, &motion_limits, &cmd_in);
-          memcpy(&(traj_seg_reply.error_message), trajectory_manager.seg_load_error_message, min(100, strlen(trajectory_manager.seg_load_error_message)));
+          memset(&(traj_seg_reply.error_message), 0, 100);
+          strcpy(traj_seg_reply.error_message, trajectory_manager.seg_load_error_message);
           rpc_out[0]=RPC_REPLY_SET_NEXT_TRAJECTORY_SEG;
           memcpy(rpc_out + 1, (uint8_t *) (&traj_seg_reply), sizeof(TrajectorySegmentReply)); 
           num_byte_rpc_out=sizeof(TrajectorySegmentReply)+1;
@@ -287,7 +288,8 @@ void handleNewRPC()
     case RPC_START_NEW_TRAJECTORY: 
           memcpy(&traj_seg_in, rpc_in+1, sizeof(TrajectorySegment)); //copy in the new segment
           traj_seg_reply.success=trajectory_manager.start_new_trajectory(&traj_seg_in, sync_manager.sync_mode_enabled, motion_limits_set, &motion_limits, &cmd_in);
-          memcpy(&(traj_seg_reply.error_message), trajectory_manager.seg_load_error_message, min(100, strlen(trajectory_manager.seg_load_error_message)));
+          memset(&(traj_seg_reply.error_message), 0, 100);
+          strcpy(traj_seg_reply.error_message, trajectory_manager.seg_load_error_message);
           rpc_out[0]=RPC_REPLY_START_NEW_TRAJECTORY;
           memcpy(rpc_out + 1, (uint8_t *) (&traj_seg_reply), sizeof(TrajectorySegmentReply)); 
           num_byte_rpc_out=sizeof(TrajectorySegmentReply)+1;

--- a/arduino/hello_stepper/HelloController.cpp
+++ b/arduino/hello_stepper/HelloController.cpp
@@ -278,7 +278,7 @@ void handleNewRPC()
           break;
     case RPC_SET_NEXT_TRAJECTORY_SEG: 
           memcpy(&traj_seg_in, rpc_in+1, sizeof(TrajectorySegment)); //copy in the new segment
-          traj_seg_reply.success=trajectory_manager.set_next_trajectory_segment(&traj_seg_in, motion_limits_set, &motion_limits, &cmd_in);
+          traj_seg_reply.success=trajectory_manager.set_next_trajectory_segment(&traj_seg_in, motion_limits_set, diag_pos_calibrated, &motion_limits, &cmd_in);
           memset(&(traj_seg_reply.error_message), 0, 100);
           strcpy(traj_seg_reply.error_message, trajectory_manager.seg_load_error_message);
           rpc_out[0]=RPC_REPLY_SET_NEXT_TRAJECTORY_SEG;
@@ -287,7 +287,7 @@ void handleNewRPC()
           break;
     case RPC_START_NEW_TRAJECTORY: 
           memcpy(&traj_seg_in, rpc_in+1, sizeof(TrajectorySegment)); //copy in the new segment
-          traj_seg_reply.success=trajectory_manager.start_new_trajectory(&traj_seg_in, sync_manager.sync_mode_enabled, motion_limits_set, &motion_limits, &cmd_in);
+          traj_seg_reply.success=trajectory_manager.start_new_trajectory(&traj_seg_in, sync_manager.sync_mode_enabled, motion_limits_set, diag_pos_calibrated, &motion_limits, &cmd_in);
           memset(&(traj_seg_reply.error_message), 0, 100);
           strcpy(traj_seg_reply.error_message, trajectory_manager.seg_load_error_message);
           rpc_out[0]=RPC_REPLY_START_NEW_TRAJECTORY;

--- a/arduino/hello_stepper/HelloController.cpp
+++ b/arduino/hello_stepper/HelloController.cpp
@@ -278,7 +278,7 @@ void handleNewRPC()
           break;
     case RPC_SET_NEXT_TRAJECTORY_SEG: 
           memcpy(&traj_seg_in, rpc_in+1, sizeof(TrajectorySegment)); //copy in the new segment
-          traj_seg_reply.success=trajectory_manager.set_next_trajectory_segment(&traj_seg_in, &motion_limits, &cmd_in);
+          traj_seg_reply.success=trajectory_manager.set_next_trajectory_segment(&traj_seg_in, motion_limits_set, &motion_limits, &cmd_in);
           memcpy(&(traj_seg_reply.error_message), trajectory_manager.seg_load_error_message, min(100, strlen(trajectory_manager.seg_load_error_message)));
           rpc_out[0]=RPC_REPLY_SET_NEXT_TRAJECTORY_SEG;
           memcpy(rpc_out + 1, (uint8_t *) (&traj_seg_reply), sizeof(TrajectorySegmentReply)); 
@@ -286,7 +286,7 @@ void handleNewRPC()
           break;
     case RPC_START_NEW_TRAJECTORY: 
           memcpy(&traj_seg_in, rpc_in+1, sizeof(TrajectorySegment)); //copy in the new segment
-          traj_seg_reply.success=trajectory_manager.start_new_trajectory(&traj_seg_in, sync_manager.sync_mode_enabled, &motion_limits, &cmd_in);
+          traj_seg_reply.success=trajectory_manager.start_new_trajectory(&traj_seg_in, sync_manager.sync_mode_enabled, motion_limits_set, &motion_limits, &cmd_in);
           memcpy(&(traj_seg_reply.error_message), trajectory_manager.seg_load_error_message, min(100, strlen(trajectory_manager.seg_load_error_message)));
           rpc_out[0]=RPC_REPLY_START_NEW_TRAJECTORY;
           memcpy(rpc_out + 1, (uint8_t *) (&traj_seg_reply), sizeof(TrajectorySegmentReply)); 

--- a/arduino/hello_stepper/HelloController.cpp
+++ b/arduino/hello_stepper/HelloController.cpp
@@ -278,14 +278,16 @@ void handleNewRPC()
           break;
     case RPC_SET_NEXT_TRAJECTORY_SEG: 
           memcpy(&traj_seg_in, rpc_in+1, sizeof(TrajectorySegment)); //copy in the new segment
-          traj_seg_reply.success=trajectory_manager.set_next_trajectory_segment(&traj_seg_in);
+          traj_seg_reply.success=trajectory_manager.set_next_trajectory_segment(&traj_seg_in, &motion_limits, &cmd_in);
+          memcpy(&(traj_seg_reply.error_message), trajectory_manager.seg_load_error_message, min(100, strlen(trajectory_manager.seg_load_error_message)));
           rpc_out[0]=RPC_REPLY_SET_NEXT_TRAJECTORY_SEG;
           memcpy(rpc_out + 1, (uint8_t *) (&traj_seg_reply), sizeof(TrajectorySegmentReply)); 
           num_byte_rpc_out=sizeof(TrajectorySegmentReply)+1;
           break;
     case RPC_START_NEW_TRAJECTORY: 
           memcpy(&traj_seg_in, rpc_in+1, sizeof(TrajectorySegment)); //copy in the new segment
-          traj_seg_reply.success=trajectory_manager.start_new_trajectory(&traj_seg_in, sync_manager.sync_mode_enabled );
+          traj_seg_reply.success=trajectory_manager.start_new_trajectory(&traj_seg_in, sync_manager.sync_mode_enabled, &motion_limits, &cmd_in);
+          memcpy(&(traj_seg_reply.error_message), trajectory_manager.seg_load_error_message, min(100, strlen(trajectory_manager.seg_load_error_message)));
           rpc_out[0]=RPC_REPLY_START_NEW_TRAJECTORY;
           memcpy(rpc_out + 1, (uint8_t *) (&traj_seg_reply), sizeof(TrajectorySegmentReply)); 
           num_byte_rpc_out=sizeof(TrajectorySegmentReply)+1;

--- a/arduino/hello_stepper/TrajectoryManager.cpp
+++ b/arduino/hello_stepper/TrajectoryManager.cpp
@@ -140,10 +140,10 @@ void TrajectoryManager::step()
 
 //Called from RPC loop
 //Return 1 for success
-bool TrajectoryManager::set_next_trajectory_segment(TrajectorySegment * s, bool motion_limits_set, MotionLimits * m, Command * c)
+bool TrajectoryManager::set_next_trajectory_segment(TrajectorySegment * s, bool motion_limits_set, bool diag_pos_calibrated, MotionLimits * m, Command * c)
 {
   memset(&(seg_load_error_message), 0, 100);
-  // if (!is_segment_valid(s, motion_limits_set, m, c))
+  // if (!is_segment_valid(s, motion_limits_set, diag_pos_calibrated, m, c))
   // {
   //   // 'seg_load_error_message' set within call to 'is_segment_valid'
   //   return 0;
@@ -179,10 +179,10 @@ bool TrajectoryManager::set_next_trajectory_segment(TrajectorySegment * s, bool 
 
 //Called from RPC loop
 //Return 1 for success
-bool TrajectoryManager::start_new_trajectory(TrajectorySegment * s, bool wait_on_sync, bool motion_limits_set, MotionLimits * m, Command * c)
+bool TrajectoryManager::start_new_trajectory(TrajectorySegment * s, bool wait_on_sync, bool motion_limits_set, bool diag_pos_calibrated, MotionLimits * m, Command * c)
 {
   memset(&(seg_load_error_message), 0, 100);
-  // if (!is_segment_valid(s, motion_limits_set, m, c))
+  // if (!is_segment_valid(s, motion_limits_set, diag_pos_calibrated, m, c))
   // {
   //   // 'seg_load_error_message' set within call to 'is_segment_valid'
   //   return 0;
@@ -221,7 +221,7 @@ bool TrajectoryManager::start_new_trajectory(TrajectorySegment * s, bool wait_on
 //Determines whether a segment is executable by evaluating along it
 //and checking for infeasible positions, velocities, and accelerations
 //Return 1 for valid segment
-bool TrajectoryManager::is_segment_valid(TrajectorySegment * s, bool motion_limits_set, MotionLimits * m, Command * c)
+bool TrajectoryManager::is_segment_valid(TrajectorySegment * s, bool motion_limits_set, bool diag_pos_calibrated, MotionLimits * m, Command * c)
 {
   TrajectorySegment a = *s;
   float t1 = 0.0;
@@ -237,7 +237,7 @@ bool TrajectoryManager::is_segment_valid(TrajectorySegment * s, bool motion_limi
     float acc_t = (2.0 * a.a2) + (6.0 * a.a3 * t1) + (12 * a.a4 * t2) + (20 * a.a5 * t3);
 
     // check position within soft motion limits
-    if (motion_limits_set && (pos_t < m->pos_min || pos_t > m->pos_max)) {
+    if (motion_limits_set && diag_pos_calibrated && (pos_t < m->pos_min || pos_t > m->pos_max)) {
       strncpy(seg_load_error_message, "invalid segment exceeds position limits", 100);
       return 0;
     }

--- a/arduino/hello_stepper/TrajectoryManager.cpp
+++ b/arduino/hello_stepper/TrajectoryManager.cpp
@@ -143,28 +143,28 @@ bool TrajectoryManager::set_next_trajectory_segment(TrajectorySegment * s, bool 
 {
   memset(&(seg_load_error_message), 0, 100);
 
-  if (!is_segment_valid(s, motion_limits_set, diag_pos_calibrated, m, c))
-  {
-    // 'seg_load_error_message' set within call to 'is_segment_valid'
-    return 0;
-  }
+  // if (!is_segment_valid(s, motion_limits_set, diag_pos_calibrated, m, c))
+  // {
+  //   // 'seg_load_error_message' set within call to 'is_segment_valid'
+  //   return 0;
+  // }
 
   if (state==TRAJ_STATE_IDLE)
   {
     strcpy(seg_load_error_message, "cannot set next trajectory segment while no previous trajectory active");
-    return 0;
+    return 1;
   }
   if (state==TRAJ_STATE_WAITING_ON_SYNC)
   {
     strcpy(seg_load_error_message, "cannot set next trajectory segment while previous trajectory waiting on sync");
-    return 0;
+    return 1;
   }
   if (state==TRAJ_STATE_ACTIVE) //Don't allow setting of next segment until current one is started
   {
     if (s->id != seg_active.id + 1)
     {
       strcpy(seg_load_error_message, "next trajectory segment id must follow previous segment id");
-      return 0;
+      return 1;
     }
 
     seg_in=*s;
@@ -183,11 +183,11 @@ bool TrajectoryManager::start_new_trajectory(TrajectorySegment * s, bool wait_on
 {
   memset(&(seg_load_error_message), 0, 100);
 
-  if (!is_segment_valid(s, motion_limits_set, diag_pos_calibrated, m, c))
-  {
-    // 'seg_load_error_message' set within call to 'is_segment_valid'
-    return 0;
-  }
+  // if (!is_segment_valid(s, motion_limits_set, diag_pos_calibrated, m, c))
+  // {
+  //   // 'seg_load_error_message' set within call to 'is_segment_valid'
+  //   return 0;
+  // }
 
   if (state==TRAJ_STATE_IDLE) //Don't allow starting of new trajectory until current one is done
   {

--- a/arduino/hello_stepper/TrajectoryManager.cpp
+++ b/arduino/hello_stepper/TrajectoryManager.cpp
@@ -34,7 +34,7 @@ TrajectoryManager::TrajectoryManager()
     start_new=false;
     seg_active_valid=false;
     seg_next_valid=false;
-    strncpy(seg_load_error_message, "", 100);
+    memset(&(seg_load_error_message), 0, 100);
     id_curr_seg=0;
     waiting_on_sync=false;
 }
@@ -142,37 +142,38 @@ void TrajectoryManager::step()
 //Return 1 for success
 bool TrajectoryManager::set_next_trajectory_segment(TrajectorySegment * s, bool motion_limits_set, MotionLimits * m, Command * c)
 {
-  if (!is_segment_valid(s, motion_limits_set, m, c))
-  {
-    // 'seg_load_error_message' set within call to 'is_segment_valid'
-    return 0;
-  }
+  memset(&(seg_load_error_message), 0, 100);
+  // if (!is_segment_valid(s, motion_limits_set, m, c))
+  // {
+  //   // 'seg_load_error_message' set within call to 'is_segment_valid'
+  //   return 0;
+  // }
 
   if (state==TRAJ_STATE_IDLE)
   {
-    strncpy(seg_load_error_message, "cannot set next trajectory segment while no previous trajectory active", 100);
+    strcpy(seg_load_error_message, "cannot set next trajectory segment while no previous trajectory active");
     return 0;
   }
   if (state==TRAJ_STATE_WAITING_ON_SYNC)
   {
-    strncpy(seg_load_error_message, "cannot set next trajectory segment while previous trajectory waiting on sync", 100);
+    strcpy(seg_load_error_message, "cannot set next trajectory segment while previous trajectory waiting on sync");
     return 0;
   }
   if (state==TRAJ_STATE_ACTIVE) //Don't allow setting of next segment until current one is started
   {
     if (s->id != seg_active.id + 1)
     {
-      strncpy(seg_load_error_message, "next trajectory segment id must follow previous segment id", 100);
+      strcpy(seg_load_error_message, "next trajectory segment id must follow previous segment id");
       return 0;
     }
 
     seg_in=*s;
     dirty_seg_in=true; //Flag to add on next step cycle (hanlde in irq, not RPC loop
-    strncpy(seg_load_error_message, "", 100);
+    memset(&(seg_load_error_message), 0, 100);
     return 1;
   }
 
-  strncpy(seg_load_error_message, "unknown error", 100);
+  strcpy(seg_load_error_message, "unknown error");
   return 0;
 }
 
@@ -180,17 +181,18 @@ bool TrajectoryManager::set_next_trajectory_segment(TrajectorySegment * s, bool 
 //Return 1 for success
 bool TrajectoryManager::start_new_trajectory(TrajectorySegment * s, bool wait_on_sync, bool motion_limits_set, MotionLimits * m, Command * c)
 {
-  if (!is_segment_valid(s, motion_limits_set, m, c))
-  {
-    // 'seg_load_error_message' set within call to 'is_segment_valid'
-    return 0;
-  }
+  memset(&(seg_load_error_message), 0, 100);
+  // if (!is_segment_valid(s, motion_limits_set, m, c))
+  // {
+  //   // 'seg_load_error_message' set within call to 'is_segment_valid'
+  //   return 0;
+  // }
 
   if (state==TRAJ_STATE_IDLE) //Don't allow starting of new trajectory until current one is done
   {
     if (s->id != 2)
     {
-      strncpy(seg_load_error_message, "starting trajectory segment id must be 2", 100);
+      strcpy(seg_load_error_message, "starting trajectory segment id must be 2");
       return 0;
     }
 
@@ -198,21 +200,21 @@ bool TrajectoryManager::start_new_trajectory(TrajectorySegment * s, bool wait_on
     seg_in=*s;
     dirty_seg_in=true; //Flag to add on next step cycle (hanlde in irq, not RPC loop
     waiting_on_sync=wait_on_sync;
-    strncpy(seg_load_error_message, "", 100);
+    memset(&(seg_load_error_message), 0, 100);
     return 1;
   }
   if (state==TRAJ_STATE_WAITING_ON_SYNC)
   {
-    strncpy(seg_load_error_message, "cannot start new trajectory while previous trajectory waiting on sync", 100);
+    strcpy(seg_load_error_message, "cannot start new trajectory while previous trajectory waiting on sync");
     return 0;
   }
   if (state==TRAJ_STATE_ACTIVE)
   {
-    strncpy(seg_load_error_message, "cannot start new trajectory while previous trajectory active", 100);
+    strcpy(seg_load_error_message, "cannot start new trajectory while previous trajectory active");
     return 0;
   }
 
-  strncpy(seg_load_error_message, "unknown error", 100);
+  strcpy(seg_load_error_message, "unknown error");
   return 0;
 }
 

--- a/arduino/hello_stepper/TrajectoryManager.cpp
+++ b/arduino/hello_stepper/TrajectoryManager.cpp
@@ -140,7 +140,7 @@ void TrajectoryManager::step()
 
 //Called from RPC loop
 //Return 1 for success
-bool TrajectoryManager::set_next_trajectory_segment(TrajectorySegment * s, MotionLimits * m, Command * c)
+bool TrajectoryManager::set_next_trajectory_segment(TrajectorySegment * s, bool motion_limits_set, MotionLimits * m, Command * c)
 {
   if (state==TRAJ_STATE_ACTIVE) //Don't allow starting of new trajectory until current one is done
   {
@@ -155,7 +155,7 @@ bool TrajectoryManager::set_next_trajectory_segment(TrajectorySegment * s, Motio
 
 //Called from RPC loop
 //Return 1 for success
-bool TrajectoryManager::start_new_trajectory(TrajectorySegment * s, bool wait_on_sync, MotionLimits * m, Command * c)
+bool TrajectoryManager::start_new_trajectory(TrajectorySegment * s, bool wait_on_sync, bool motion_limits_set, MotionLimits * m, Command * c)
 {
   if (state==TRAJ_STATE_IDLE) //Don't allow starting of new trajectory until current one is done
   {
@@ -171,7 +171,7 @@ bool TrajectoryManager::start_new_trajectory(TrajectorySegment * s, bool wait_on
 //Determines whether a segment is executable by evaluating along it
 //and checking for infeasible positions, velocities, and accelerations
 //Return 1 for valid segment
-bool TrajectoryManager::is_segment_valid(TrajectorySegment * s, MotionLimits * m, Command * c)
+bool TrajectoryManager::is_segment_valid(TrajectorySegment * s, bool motion_limits_set, MotionLimits * m, Command * c)
 {
   TrajectorySegment a = *s;
   float t1 = 0.0;
@@ -187,7 +187,7 @@ bool TrajectoryManager::is_segment_valid(TrajectorySegment * s, MotionLimits * m
     float acc_t = (2.0 * a.a2) + (6.0 * a.a3 * t1) + (12 * a.a4 * t2) + (20 * a.a5 * t3);
 
     // check position within soft motion limits
-    if (pos_t < m->pos_min || pos_t > m->pos_max) {
+    if (motion_limits_set && (pos_t < m->pos_min || pos_t > m->pos_max)) {
       strncpy(seg_load_error_message, "invalid segment exceeds position limits", 100);
       return 0;
     }

--- a/arduino/hello_stepper/TrajectoryManager.cpp
+++ b/arduino/hello_stepper/TrajectoryManager.cpp
@@ -143,11 +143,11 @@ bool TrajectoryManager::set_next_trajectory_segment(TrajectorySegment * s, bool 
 {
   memset(&(seg_load_error_message), 0, 100);
 
-  if (!is_segment_valid(s, motion_limits_set, diag_pos_calibrated, m, c))
-  {
-    // 'seg_load_error_message' set within call to 'is_segment_valid'
-    return 0;
-  }
+  // if (!is_segment_valid(s, motion_limits_set, diag_pos_calibrated, m, c))
+  // {
+  //   // 'seg_load_error_message' set within call to 'is_segment_valid'
+  //   return 0;
+  // }
 
   if (state==TRAJ_STATE_IDLE)
   {
@@ -183,11 +183,11 @@ bool TrajectoryManager::start_new_trajectory(TrajectorySegment * s, bool wait_on
 {
   memset(&(seg_load_error_message), 0, 100);
 
-  if (!is_segment_valid(s, motion_limits_set, diag_pos_calibrated, m, c))
-  {
-    // 'seg_load_error_message' set within call to 'is_segment_valid'
-    return 0;
-  }
+  // if (!is_segment_valid(s, motion_limits_set, diag_pos_calibrated, m, c))
+  // {
+  //   // 'seg_load_error_message' set within call to 'is_segment_valid'
+  //   return 0;
+  // }
 
   if (state==TRAJ_STATE_IDLE) //Don't allow starting of new trajectory until current one is done
   {

--- a/arduino/hello_stepper/TrajectoryManager.cpp
+++ b/arduino/hello_stepper/TrajectoryManager.cpp
@@ -142,14 +142,37 @@ void TrajectoryManager::step()
 //Return 1 for success
 bool TrajectoryManager::set_next_trajectory_segment(TrajectorySegment * s, bool motion_limits_set, MotionLimits * m, Command * c)
 {
-  if (state==TRAJ_STATE_ACTIVE) //Don't allow starting of new trajectory until current one is done
+  if (!is_segment_valid(s, motion_limits_set, m, c))
   {
-    seg_in=*s;
-    dirty_seg_in=true; //Flag to add on next step cycle (hanlde in irq, not RPC loop
-    return seg_active.id;
+    // 'seg_load_error_message' set within call to 'is_segment_valid'
+    return 0;
+  }
+
+  if (state==TRAJ_STATE_IDLE)
+  {
+    strncpy(seg_load_error_message, "cannot set next trajectory segment while no previous trajectory active", 100);
+    return 0;
   }
   if (state==TRAJ_STATE_WAITING_ON_SYNC)
+  {
+    strncpy(seg_load_error_message, "cannot set next trajectory segment while previous trajectory waiting on sync", 100);
+    return 0;
+  }
+  if (state==TRAJ_STATE_ACTIVE) //Don't allow setting of next segment until current one is started
+  {
+    if (s->id != seg_active.id + 1)
+    {
+      strncpy(seg_load_error_message, "next trajectory segment id must follow previous segment id", 100);
+      return 0;
+    }
+
+    seg_in=*s;
+    dirty_seg_in=true; //Flag to add on next step cycle (hanlde in irq, not RPC loop
+    strncpy(seg_load_error_message, "", 100);
     return 1;
+  }
+
+  strncpy(seg_load_error_message, "unknown error", 100);
   return 0;
 }
 
@@ -157,14 +180,39 @@ bool TrajectoryManager::set_next_trajectory_segment(TrajectorySegment * s, bool 
 //Return 1 for success
 bool TrajectoryManager::start_new_trajectory(TrajectorySegment * s, bool wait_on_sync, bool motion_limits_set, MotionLimits * m, Command * c)
 {
+  if (!is_segment_valid(s, motion_limits_set, m, c))
+  {
+    // 'seg_load_error_message' set within call to 'is_segment_valid'
+    return 0;
+  }
+
   if (state==TRAJ_STATE_IDLE) //Don't allow starting of new trajectory until current one is done
   {
+    if (s->id != 2)
+    {
+      strncpy(seg_load_error_message, "starting trajectory segment id must be 2", 100);
+      return 0;
+    }
+
     start_new=true;
     seg_in=*s;
     dirty_seg_in=true; //Flag to add on next step cycle (hanlde in irq, not RPC loop
     waiting_on_sync=wait_on_sync;
+    strncpy(seg_load_error_message, "", 100);
     return 1;
   }
+  if (state==TRAJ_STATE_WAITING_ON_SYNC)
+  {
+    strncpy(seg_load_error_message, "cannot start new trajectory while previous trajectory waiting on sync", 100);
+    return 0;
+  }
+  if (state==TRAJ_STATE_ACTIVE)
+  {
+    strncpy(seg_load_error_message, "cannot start new trajectory while previous trajectory active", 100);
+    return 0;
+  }
+
+  strncpy(seg_load_error_message, "unknown error", 100);
   return 0;
 }
 

--- a/arduino/hello_stepper/TrajectoryManager.cpp
+++ b/arduino/hello_stepper/TrajectoryManager.cpp
@@ -143,11 +143,11 @@ bool TrajectoryManager::set_next_trajectory_segment(TrajectorySegment * s, bool 
 {
   memset(&(seg_load_error_message), 0, 100);
 
-  // if (!is_segment_valid(s, motion_limits_set, diag_pos_calibrated, m, c))
-  // {
-  //   // 'seg_load_error_message' set within call to 'is_segment_valid'
-  //   return 0;
-  // }
+  if (!is_segment_valid(s, motion_limits_set, diag_pos_calibrated, m, c))
+  {
+    // 'seg_load_error_message' set within call to 'is_segment_valid'
+    return 0;
+  }
 
   if (state==TRAJ_STATE_IDLE)
   {
@@ -183,11 +183,11 @@ bool TrajectoryManager::start_new_trajectory(TrajectorySegment * s, bool wait_on
 {
   memset(&(seg_load_error_message), 0, 100);
 
-  // if (!is_segment_valid(s, motion_limits_set, diag_pos_calibrated, m, c))
-  // {
-  //   // 'seg_load_error_message' set within call to 'is_segment_valid'
-  //   return 0;
-  // }
+  if (!is_segment_valid(s, motion_limits_set, diag_pos_calibrated, m, c))
+  {
+    // 'seg_load_error_message' set within call to 'is_segment_valid'
+    return 0;
+  }
 
   if (state==TRAJ_STATE_IDLE) //Don't allow starting of new trajectory until current one is done
   {
@@ -226,7 +226,7 @@ bool TrajectoryManager::is_segment_valid(TrajectorySegment * s, bool motion_limi
 {
   TrajectorySegment a = *s;
   float t1 = 0.0;
-  while (t1 <= a.tf) {
+  while (t1 < a.tf) {
     float t2 = t1 * t1;
     float t3 = t2 * t1;
     float t4 = t3 * t1;
@@ -255,7 +255,7 @@ bool TrajectoryManager::is_segment_valid(TrajectorySegment * s, bool motion_limi
       return 0;
     }
 
-    t1 = min(a.tf, t1 + 0.5); // sample along segment every 0.5 seconds
+    t1 = min(a.tf, t1 + 0.1); // sample along segment every 0.1 seconds
   }
 
   return 1;

--- a/arduino/hello_stepper/TrajectoryManager.h
+++ b/arduino/hello_stepper/TrajectoryManager.h
@@ -23,13 +23,13 @@ class  TrajectoryManager{
    public: 
     TrajectoryManager();
     void step(); //Called at 1Khz by TC4 loop
-    bool set_next_trajectory_segment(TrajectorySegment * s, MotionLimits * m, Command * c);
-    bool start_new_trajectory(TrajectorySegment * s,  bool wait_on_sync, MotionLimits * m, Command * c);
+    bool set_next_trajectory_segment(TrajectorySegment * s, bool motion_limits_set, MotionLimits * m, Command * c);
+    bool start_new_trajectory(TrajectorySegment * s,  bool wait_on_sync, bool motion_limits_set, MotionLimits * m, Command * c);
     void reset();
     bool is_trajectory_active();
     bool is_trajectory_waiting_on_sync();
     bool is_trajectory_idle();
-    bool is_segment_valid(TrajectorySegment * s, MotionLimits * m, Command * c);
+    bool is_segment_valid(TrajectorySegment * s, bool motion_limits_set, MotionLimits * m, Command * c);
     uint16_t get_id_current_segment(){return id_curr_seg;}
     float q; //current position target
     bool waiting_on_sync;

--- a/arduino/hello_stepper/TrajectoryManager.h
+++ b/arduino/hello_stepper/TrajectoryManager.h
@@ -23,15 +23,17 @@ class  TrajectoryManager{
    public: 
     TrajectoryManager();
     void step(); //Called at 1Khz by TC4 loop
-    bool set_next_trajectory_segment(TrajectorySegment * s);
-    bool start_new_trajectory(TrajectorySegment * s,  bool wait_on_sync);
+    bool set_next_trajectory_segment(TrajectorySegment * s, MotionLimits * m, Command * c);
+    bool start_new_trajectory(TrajectorySegment * s,  bool wait_on_sync, MotionLimits * m, Command * c);
     void reset();
     bool is_trajectory_active();
     bool is_trajectory_waiting_on_sync();
     bool is_trajectory_idle();
+    bool is_segment_valid(TrajectorySegment * s, MotionLimits * m, Command * c);
     uint16_t get_id_current_segment(){return id_curr_seg;}
     float q; //current position target
     bool waiting_on_sync;
+    char seg_load_error_message[100];
   private:
     
     uint16_t id_curr_seg;

--- a/arduino/hello_stepper/TrajectoryManager.h
+++ b/arduino/hello_stepper/TrajectoryManager.h
@@ -23,13 +23,13 @@ class  TrajectoryManager{
    public: 
     TrajectoryManager();
     void step(); //Called at 1Khz by TC4 loop
-    bool set_next_trajectory_segment(TrajectorySegment * s, bool motion_limits_set, MotionLimits * m, Command * c);
-    bool start_new_trajectory(TrajectorySegment * s,  bool wait_on_sync, bool motion_limits_set, MotionLimits * m, Command * c);
+    bool set_next_trajectory_segment(TrajectorySegment * s, bool motion_limits_set, bool diag_pos_calibrated, MotionLimits * m, Command * c);
+    bool start_new_trajectory(TrajectorySegment * s,  bool wait_on_sync, bool motion_limits_set, bool diag_pos_calibrated, MotionLimits * m, Command * c);
     void reset();
     bool is_trajectory_active();
     bool is_trajectory_waiting_on_sync();
     bool is_trajectory_idle();
-    bool is_segment_valid(TrajectorySegment * s, bool motion_limits_set, MotionLimits * m, Command * c);
+    bool is_segment_valid(TrajectorySegment * s, bool motion_limits_set, bool diag_pos_calibrated, MotionLimits * m, Command * c);
     uint16_t get_id_current_segment(){return id_curr_seg;}
     float q; //current position target
     bool waiting_on_sync;


### PR DESCRIPTION
This PR changes the firmware to include 'error_message' in the TrajectorySegmentReply RPC. This allows the firmware to report what is wrong with the segment that was sent. Additionally, the firmware evaluates at 0.1 second increments along the segment to verify that velocity and acceleration dynamic limits are exceeded by the trajectory. If they are, then the segment is rejected.

Tested with https://github.com/hello-robot/stretch_body/pull/103 on Python2, Ubuntu 18.04.