### PR TITLE
Feature/watchdog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ ENV/
 
 # mypy
 .mypy_cache/
+
+# vscode
+.vscode/

--- a/arduino/hello_pimu/Common.h
+++ b/arduino/hello_pimu/Common.h
@@ -27,6 +27,7 @@
 // Version 0.2.5: Initial production release for RE2 Nina
 // Version 0.2.6: Add trace function
 // Version 0.3.0: Move to updated trace and protocol P2
+// Version 0.3.1: Added Watchdog timer (WDT) reset feture
 
 #define FIRMWARE_VERSION "Pimu.v0.3.1p2"
 

--- a/arduino/hello_pimu/Common.h
+++ b/arduino/hello_pimu/Common.h
@@ -28,7 +28,7 @@
 // Version 0.2.6: Add trace function
 // Version 0.3.0: Move to updated trace and protocol P2
 
-#define FIRMWARE_VERSION "Pimu.v0.3.0p2"
+#define FIRMWARE_VERSION "Pimu.v0.3.1p2"
 
 #define FS 100 //Loop rate in Hz for TC5
 

--- a/arduino/hello_pimu/Common.h
+++ b/arduino/hello_pimu/Common.h
@@ -27,7 +27,7 @@
 // Version 0.2.5: Initial production release for RE2 Nina
 // Version 0.2.6: Add trace function
 // Version 0.3.0: Move to updated trace and protocol P2
-// Version 0.3.1: Added Watchdog timer (WDT) reset feture
+// Version 0.3.1: Added Watchdog timer (WDT) reset feture, halved trace buffer
 
 #define FIRMWARE_VERSION "Pimu.v0.3.1p2"
 

--- a/arduino/hello_pimu/Pimu.cpp
+++ b/arduino/hello_pimu/Pimu.cpp
@@ -66,6 +66,9 @@ void setupTimer4_and_5();
 void toggle_led(int rate_ms);
 uint32_t cycle_cnt=0;
 
+void resetWDT();
+void setupWDT(uint8_t period);
+
 
 /////////////////////////////////////////////////////////////////////////
 float deg_to_rad(float x)
@@ -80,6 +83,7 @@ float rad_to_deg(float x)
 #define TC5_TICKS_PER_CYCLE (int)( round(48000000 / 16 / FS)) //30,000 at 100hz, 16:1 prescalar TC5 is 32bit timer
 #define US_PER_TC5_CYCLE 1000000/FS //10000 at 100Hz
 #define US_PER_TC5_TICK 1000000.0*16/48000000 //0.33us resolution
+#define WDT_TIMEOUT_PERIOD 11 //ms range 0-11ms
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 void handle_trigger();
@@ -162,6 +166,7 @@ void setupPimu() {
   memcpy(&(board_info.firmware_version),FIRMWARE_VERSION,min(20,strlen(FIRMWARE_VERSION)));
   analog_manager.setupADC();
   setupTimer4_and_5();
+  setupWDT(WDT_TIMEOUT_PERIOD);
   time_manager.clock_zero();
   
 }
@@ -254,6 +259,7 @@ void handleNewRPC()
 void stepPimuRPC()
 {
   stepTransport(handleNewRPC);
+  resetWDT();
 }
 
 
@@ -516,6 +522,39 @@ void update_status()
   {
     trace_manager.update_trace_status(&stat_out);
   }
+}
+
+/////////////////////// Watchdog //////////////////////////////////////
+// reference https://forum.arduino.cc/t/wdt-watchdog-timer-code/353610
+
+void WDTsync() {
+  while (WDT->STATUS.bit.SYNCBUSY == 1); //Just wait till WDT is free
+}
+
+void resetWDT() {
+  // reset the WDT watchdog timer.
+  // this must be called before the WDT resets the system
+  WDT->CLEAR.reg= 0xA5; // reset the WDT
+  WDTsync(); 
+}
+
+void systemReset() {
+  // use the WDT watchdog timer to force a system reset.
+  // WDT MUST be running for this to work
+  WDT->CLEAR.reg= 0x00; // system reset via WDT
+  WDTsync(); 
+}
+
+void setupWDT( uint8_t period) {
+  // initialize the WDT watchdog timer
+
+  WDT->CTRL.reg = 0; // disable watchdog
+  WDTsync(); // sync is required
+
+  WDT->CONFIG.reg = min(period,11); // see Table 17-5 Timeout Period (valid values 0-11) (ms)
+
+  WDT->CTRL.reg = WDT_CTRL_ENABLE; //enable watchdog
+  WDTsync(); 
 }
 
 ////////////////////// Timer5 /////////////////////////////////////////

--- a/arduino/hello_pimu/TraceManager.h
+++ b/arduino/hello_pimu/TraceManager.h
@@ -38,11 +38,11 @@
  */
  
 /////////////////////////// TRACE //////////////////////////////////////
-#define N_TRACE_RAW 22800  //Raw buffer. Allocate enough for min 250 Status messages / 1000 debug messages / 250 print messages
-#define N_TRACE_STATUS 200 //Status message is 114 bytes ea
-#define N_TRACE_DEBUG 1000 //Debug message is 14 bytes ea
+#define N_TRACE_RAW 11400  //Raw buffer. (DO NOT INCREASE THIS MEMORY) Allocate enough for min 250 Status messages / 1000 debug messages / 250 print messages
+#define N_TRACE_STATUS 100 //Status message is 114 bytes ea
+#define N_TRACE_DEBUG 500 //Debug message is 14 bytes ea
 #define N_TRACE_PRINT_LN 32
-#define N_TRACE_PRINT 400   //Print message is 44 bytes ea
+#define N_TRACE_PRINT 200   //Print message is 44 bytes ea
 
 struct __attribute__ ((packed)) DebugTrace{ //14 bytes
   uint8_t u8_1;

--- a/arduino/hello_stepper/Common.h
+++ b/arduino/hello_stepper/Common.h
@@ -27,7 +27,7 @@
 // Version 0.2.7: Add velocity watchdog
 // Version 0.2.8: Add trace function
 // Version 0.3.0: Move to updated trace and protocol P2
-// Version 0.3.1: Added Watchdog timer (WDT) reset feture
+// Version 0.3.1: Added Watchdog timer (WDT) reset feture, halved trace buffer
 
 #define FIRMWARE_VERSION_HR "Stepper.v0.3.1p2"
 

--- a/arduino/hello_stepper/Common.h
+++ b/arduino/hello_stepper/Common.h
@@ -28,7 +28,7 @@
 // Version 0.2.8: Add trace function
 // Version 0.3.0: Move to updated trace and protocol P2
 
-#define FIRMWARE_VERSION_HR "Stepper.v0.3.0p2"
+#define FIRMWARE_VERSION_HR "Stepper.v0.3.1p2"
 
 /////////////////////////////////////////////////////////////////
 

--- a/arduino/hello_stepper/Common.h
+++ b/arduino/hello_stepper/Common.h
@@ -27,6 +27,7 @@
 // Version 0.2.7: Add velocity watchdog
 // Version 0.2.8: Add trace function
 // Version 0.3.0: Move to updated trace and protocol P2
+// Version 0.3.1: Added Watchdog timer (WDT) reset feture
 
 #define FIRMWARE_VERSION_HR "Stepper.v0.3.1p2"
 

--- a/arduino/hello_stepper/HelloController.cpp
+++ b/arduino/hello_stepper/HelloController.cpp
@@ -347,6 +347,7 @@ void handleNewRPC()
           rpc_out[0]=RPC_REPLY_MENU_ON;
           num_byte_rpc_out=1;
           switch_to_menu_cnt=5; //allow 5 rpc cycles to pass before switch to menu mode, allows any RPC replies to go out
+          disableWDT();
           break; 
     case RPC_SET_TRIGGER: 
           memcpy(&trg_in, rpc_in+1, sizeof(Trigger)); //copy in the config

--- a/arduino/hello_stepper/HelloController.cpp
+++ b/arduino/hello_stepper/HelloController.cpp
@@ -1267,3 +1267,36 @@ void disableMGInterrupts() {  //disables the controller interrupt ("closed loop 
   TC4->COUNT16.CTRLA.reg &= ~TC_CTRLA_ENABLE;   // Disable TC4
   WAIT_TC16_REGS_SYNC(TC4)                      // wait for sync
 }
+
+/////////////////////// Watchdog //////////////////////////////////////
+// reference https://forum.arduino.cc/t/wdt-watchdog-timer-code/353610
+
+void WDTsync() {
+  while (WDT->STATUS.bit.SYNCBUSY == 1); //Just wait till WDT is free
+}
+
+void resetWDT() {
+  // reset the WDT watchdog timer.
+  // this must be called before the WDT resets the system
+  WDT->CLEAR.reg= 0xA5; // reset the WDT
+  WDTsync(); 
+}
+
+void systemReset() {
+  // use the WDT watchdog timer to force a system reset.
+  // WDT MUST be running for this to work
+  WDT->CLEAR.reg= 0x00; // system reset via WDT
+  WDTsync(); 
+}
+
+void setupWDT( uint8_t period) {
+  // initialize the WDT watchdog timer
+
+  WDT->CTRL.reg = 0; // disable watchdog
+  WDTsync(); // sync is required
+
+  WDT->CONFIG.reg = min(period,11); // see Table 17-5 Timeout Period (valid values 0-11) (ms)
+
+  WDT->CTRL.reg = WDT_CTRL_ENABLE; //enable watchdog
+  WDTsync(); 
+}

--- a/arduino/hello_stepper/HelloController.cpp
+++ b/arduino/hello_stepper/HelloController.cpp
@@ -1300,3 +1300,8 @@ void setupWDT( uint8_t period) {
   WDT->CTRL.reg = WDT_CTRL_ENABLE; //enable watchdog
   WDTsync(); 
 }
+
+void disableWDT(){
+  WDT->CTRL.reg = 0; // disable watchdog
+  WDTsync(); // sync is required
+}

--- a/arduino/hello_stepper/HelloController.cpp
+++ b/arduino/hello_stepper/HelloController.cpp
@@ -1279,6 +1279,9 @@ void WDTsync() {
 void resetWDT() {
   // reset the WDT watchdog timer.
   // this must be called before the WDT resets the system
+  if(WDT->CTRL.bit.ENABLE!=1){
+    setupWDT(WDT_TIMEOUT_PERIOD);
+  }
   WDT->CLEAR.reg= 0xA5; // reset the WDT
   WDTsync(); 
 }

--- a/arduino/hello_stepper/HelloController.h
+++ b/arduino/hello_stepper/HelloController.h
@@ -40,6 +40,12 @@ extern uint8_t    BOARD_VARIANT_DRV8842;
 extern uint8_t    BOARD_VARIANT_PIN_RUNSTOP;
 extern void setupBoardVariants();
 
+extern void setupWDT( uint8_t period);
+extern void resetWDT();
+extern void WDTsync();
+extern void systemReset();
+
+#define WDT_TIMEOUT_PERIOD 11 //ms range 0-11ms
 #define TC4_LOOP_RATE 1000                                             //Update rate of control loop Hz
 #define TC4_COUNT_PER_CYCLE (int)( round(48000000 / 2/ TC4_LOOP_RATE))  //24,000 at 1Khz, 2:1 prescalar TC4 is 32bit timer 
 #define US_PER_TC4_CYCLE 1000000/TC4_LOOP_RATE                          //1000 at 1KHz

--- a/arduino/hello_stepper/HelloController.h
+++ b/arduino/hello_stepper/HelloController.h
@@ -44,6 +44,7 @@ extern void setupWDT( uint8_t period);
 extern void resetWDT();
 extern void WDTsync();
 extern void systemReset();
+extern void disableWDT();
 
 #define WDT_TIMEOUT_PERIOD 11 //ms range 0-11ms
 #define TC4_LOOP_RATE 1000                                             //Update rate of control loop Hz

--- a/arduino/hello_stepper/TraceManager.h
+++ b/arduino/hello_stepper/TraceManager.h
@@ -38,11 +38,11 @@
  */
  
 /////////////////////////// TRACE //////////////////////////////////////
-#define N_TRACE_RAW 20750  //Raw buffer. Allocate enough for min 250 Status messages / 1000 debug messages / 250 print messages
-#define N_TRACE_STATUS 250 //Status message is 83 bytes ea
-#define N_TRACE_DEBUG 1000 //Debug message is 14 bytes ea
+#define N_TRACE_RAW 10375  //Raw buffer. (DO NOT INCREASE THIS MEMORY) Allocate enough for min 125 Status messages / 1000 debug messages / 250 print messages
+#define N_TRACE_STATUS 125 //Status message is 83 bytes ea
+#define N_TRACE_DEBUG 500 //Debug message is 14 bytes ea
 #define N_TRACE_PRINT_LN 32
-#define N_TRACE_PRINT 400   //Print message is 44 bytes ea
+#define N_TRACE_PRINT 200   //Print message is 44 bytes ea
 
 struct __attribute__ ((packed)) DebugTrace{ //14 bytes
   uint8_t u8_1;

--- a/arduino/hello_stepper/hello_stepper.ino
+++ b/arduino/hello_stepper/hello_stepper.ino
@@ -38,7 +38,6 @@ void setup()        // This code runs once at startup
   setupPins();                      // configure pins
   setupTCInterrupts();              // configure controller interrupt
   
-  
 
   SerialUSB.begin(2000000); 
   
@@ -71,7 +70,7 @@ void setup()        // This code runs once at startup
     enableMGInterrupts();
     enableMotorDrivers(); //Turn on now that gains are loaded
 #endif
-
+setupWDT(WDT_TIMEOUT_PERIOD);
 }
   
 
@@ -83,6 +82,8 @@ void setup()        // This code runs once at startup
 
 void loop()                 // main loop
 {
+
+resetWDT();
 
 #ifdef HELLO
 //Flash LED fast when in menu mode, slow in RPC mode

--- a/arduino/hello_stepper/hello_stepper.ino
+++ b/arduino/hello_stepper/hello_stepper.ino
@@ -83,16 +83,16 @@ setupWDT(WDT_TIMEOUT_PERIOD);
 void loop()                 // main loop
 {
 
-resetWDT();
-
 #ifdef HELLO
 //Flash LED fast when in menu mode, slow in RPC mode
 if (hello_interface)
 {
+  resetWDT();
   stepHelloControllerRPC();
 }
 else
-{
+{ 
+  disableWDT();  // Disable WDT on menu interface because it is blocking >11ms
   serialCheck();
   toggle_led(200);
 }

--- a/arduino/hello_wacc/Common.h
+++ b/arduino/hello_wacc/Common.h
@@ -24,6 +24,8 @@
 // Version 0.2.3: Add trace function
 // Version 0.2.4: Reorg timing to fix IRQ overruns
 // Version 0.3.0: Move to updated trace and protocol P2
+// Version 0.3.1: Added Watchdog timer (WDT) reset feture
+
 #define FIRMWARE_VERSION "Wacc.v0.3.1p2"
 
 

--- a/arduino/hello_wacc/Common.h
+++ b/arduino/hello_wacc/Common.h
@@ -24,7 +24,7 @@
 // Version 0.2.3: Add trace function
 // Version 0.2.4: Reorg timing to fix IRQ overruns
 // Version 0.3.0: Move to updated trace and protocol P2
-#define FIRMWARE_VERSION "Wacc.v0.3.0p2"
+#define FIRMWARE_VERSION "Wacc.v0.3.1p2"
 
 
 /////////////////////////////////////////////////////////////////

--- a/arduino/hello_wacc/TraceManager.h
+++ b/arduino/hello_wacc/TraceManager.h
@@ -38,7 +38,7 @@
  */
  
 /////////////////////////// TRACE //////////////////////////////////////
-#define N_TRACE_RAW 14000  //Raw buffer. Allocate enough for min 250 Status messages / 1000 debug messages / 250 print messages
+#define N_TRACE_RAW 14000  //Raw buffer. (DO NOT INCREASE THIS MEMORY) Allocate enough for min 250 Status messages / 1000 debug messages / 250 print messages
 #define N_TRACE_STATUS 365 //Status message is 38 bytes ea
 #define N_TRACE_DEBUG 1000 //Debug message is 14 bytes ea
 #define N_TRACE_PRINT_LN 32

--- a/arduino/hello_wacc/Wacc.cpp
+++ b/arduino/hello_wacc/Wacc.cpp
@@ -17,7 +17,7 @@
 #include "TimeManager.h"
 #include "TraceManager.h"
 
-
+#define WDT_TIMEOUT_PERIOD 11 //ms range 0-11ms
 //////////////////////////////////////
 Wacc_Config cfg, cfg_in;
 Wacc_Command cmd, cmd_in;
@@ -38,6 +38,8 @@ bool dirty_command=false;
 void setupTimer4_and_5();
 float FS_CTRL = 70; //Run Acceleromter read Controller at 70hz
 void toggle_led(int rate_ms);
+void resetWDT();
+void setupWDT(uint8_t period);
 
 void setupWacc() {  
   memset(&cfg, 0, sizeof(Wacc_Config));
@@ -50,6 +52,7 @@ void setupWacc() {
   memcpy(&(board_info.firmware_version),FIRMWARE_VERSION,min(20,strlen(FIRMWARE_VERSION)));
   setupTimer4_and_5();
   time_manager.clock_zero();
+  setupWDT(WDT_TIMEOUT_PERIOD);
 }
 
 
@@ -121,6 +124,7 @@ void stepWaccRPC()
 {
   toggle_led(500);
   stepTransport(handleNewRPC);
+  resetWDT();
 }
 
 ////////////////////////Controller///////////////////////////////////////
@@ -348,4 +352,35 @@ void setupTimer4_and_5() {  // configure the controller interrupt
 
 
 
-//////////////////////////////////////
+/////////////////////// Watchdog //////////////////////////////////////
+// reference https://forum.arduino.cc/t/wdt-watchdog-timer-code/353610
+
+void WDTsync() {
+  while (WDT->STATUS.bit.SYNCBUSY == 1); //Just wait till WDT is free
+}
+
+void resetWDT() {
+  // reset the WDT watchdog timer.
+  // this must be called before the WDT resets the system
+  WDT->CLEAR.reg= 0xA5; // reset the WDT
+  WDTsync(); 
+}
+
+void systemReset() {
+  // use the WDT watchdog timer to force a system reset.
+  // WDT MUST be running for this to work
+  WDT->CLEAR.reg= 0x00; // system reset via WDT
+  WDTsync(); 
+}
+
+void setupWDT( uint8_t period) {
+  // initialize the WDT watchdog timer
+
+  WDT->CTRL.reg = 0; // disable watchdog
+  WDTsync(); // sync is required
+
+  WDT->CONFIG.reg = min(period,11); // see Table 17-5 Timeout Period (valid values 0-11) (ms)
+
+  WDT->CTRL.reg = WDT_CTRL_ENABLE; //enable watchdog
+  WDTsync(); 
+}


### PR DESCRIPTION
## This PR makes the following changes:
- **Added Watchdog timer (WDT)** : Introduces the WDT resets feature to all three firmwares. The WDT must be cleared with the resetWDT() method before the defined WDT_TIMEOUT_PERIOD continuously, else a system reset will be issued to the MCU. The WDT is currently cleared only from the main loop().
- **Fixes USB Descriptor/RPC issues on boot**: The issue seems to be occurring due to the ram running out of memory during the USB enumeration step. The issue was solved by halving the memory allocation for Trace manager raw_data buffer.