### PR TITLE
Fix contact_thresh_neg value for the lift

### DIFF
--- a/arduino/hello_stepper/HelloController.cpp
+++ b/arduino/hello_stepper/HelloController.cpp
@@ -817,7 +817,13 @@ void stepHelloController()
         cmd.i_contact_neg =cmd_in.i_contact_neg;
         g_eff_pos=current_to_effort(cmd.i_contact_pos);
         g_eff_neg=current_to_effort(cmd.i_contact_neg);
-      
+
+        if (g_eff_pos<g_eff_neg)
+        {
+          g_eff_pos=0;
+          g_eff_neg=0;
+        }
+        
         //If mode has changed manage smooth switchover
         if (cmd.mode!=mode_last)
         {

--- a/arduino/hello_stepper/HelloController.cpp
+++ b/arduino/hello_stepper/HelloController.cpp
@@ -815,8 +815,8 @@ void stepHelloController()
         cmd.stiffness=cmd_in.stiffness;
         cmd.i_contact_pos =cmd_in.i_contact_pos;
         cmd.i_contact_neg =cmd_in.i_contact_neg;
-        g_eff_pos=current_to_effort(abs(cmd.i_contact_pos));
-        g_eff_neg=current_to_effort(-1*abs(cmd.i_contact_neg));
+        g_eff_pos=current_to_effort(cmd.i_contact_pos);
+        g_eff_neg=current_to_effort(cmd.i_contact_neg);
       
         //If mode has changed manage smooth switchover
         if (cmd.mode!=mode_last)


### PR DESCRIPTION
The lift contact_thresh_neg value is not respected when supplied with move_to, move_by command because for the lift a sane value for this argument would still be positive. However, in HelloController, the [i_contact_neg](https://github.com/hello-robot/stretch_firmware/blob/master/arduino/hello_stepper/HelloController.cpp#L819) value is always converted to a negative value by multiplying the absolute with -1. Hence, the guarded contact [comparison](https://github.com/hello-robot/stretch_firmware/blob/master/arduino/hello_stepper/HelloController.cpp#L1196) for contact_thresh_neg always happens with a negative value at the controller level which for the lift is achieved only when a very high force is applied.

The fix in this PR gets rid of the extraneous operation with -1 as it’s not necessary if the user sets the contact_thresh_neg value with the correct sign.