### PR TITLE
generalize the motor driver off safety for base and arm

### DIFF
--- a/arduino/hello_stepper/Common.h
+++ b/arduino/hello_stepper/Common.h
@@ -35,11 +35,12 @@
 // Version 0.6.1: analogRead on voltage pin omitted
 // Version 0.6.2: Enable acceleration limits for VEL_PID
 // Version 0.6.3: Enable Decay pin of DRV8842 for lift stepper board to operate correctly
-// Version 0.7.0: Storying stepper_type to flash, to allow for wheel stepper motors to turn off when runstopped, fixed voltage input reading
+// Version 0.7.0: Storing stepper_type to flash, to allow for wheel stepper motors to turn off when runstopped, fixed voltage input reading
 // Version 0.7.1: Add the guarded contact windowing and voltage normalization (variant>=3 only)
 // Version 0.7.2: Bug fix with 0.7.1 (minor)
 // Version 0.7.3: Issue with tag system, trying version bump
-#define FIRMWARE_VERSION_HR "Stepper.v0.7.3p5"
+// Version 0.7.4: Put arm in drive-off mode when in runstop
+#define FIRMWARE_VERSION_HR "Stepper.v0.7.4p5"
 
 /////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
This makes DisableMotorDriver happen for the base and arm by default when in Safety mode (instead of conditioned on runstop). This makes these joints more backdrivable, even when the runstop is disabled but no controller is running -- eg, after a Ctrl-C).