### PR TITLE
Tilt detection

### DIFF
--- a/arduino/hello_pimu/Common.h
+++ b/arduino/hello_pimu/Common.h
@@ -36,7 +36,8 @@
 // Version 0.6.3: incorporting charging detection class
 // Version 0.7.0: added is_charger_charging state to pimu status
 // Version 0.7.1  added tilt detection feature using cliff sensor and IMU data
-#define FIRMWARE_VERSION "Pimu.v0.7.1p5"
+// Version 0.8.0  Protocol change for over_tilt_type
+#define FIRMWARE_VERSION "Pimu.v0.8.0p6"
 
 #define FS 100 //Loop rate in Hz for TC5
 
@@ -190,6 +191,7 @@ struct __attribute__ ((packed)) Pimu_Status{
   uint16_t bump_event_cnt;
   float debug;
   float current_charge;
+  uint8_t over_tilt_type;
 
 };
 

--- a/arduino/hello_pimu/Common.h
+++ b/arduino/hello_pimu/Common.h
@@ -35,7 +35,8 @@
 // Version 0.6.2: added interrupts for imu data, added writing to system orientation record for IMU orientation to match older robots
 // Version 0.6.3: incorporting charging detection class
 // Version 0.7.0: added is_charger_charging state to pimu status
-#define FIRMWARE_VERSION "Pimu.v0.7.0p5"
+// Version 0.7.1  added tilt detection feature using cliff sensor and IMU data
+#define FIRMWARE_VERSION "Pimu.v0.7.1p5"
 
 #define FS 100 //Loop rate in Hz for TC5
 

--- a/arduino/hello_pimu/Pimu.cpp
+++ b/arduino/hello_pimu/Pimu.cpp
@@ -504,13 +504,12 @@ void update_tilt_monitor()
   right_tilt = analog_manager.cliff[2] - analog_manager.cliff[0];
   forward_tilt = ((analog_manager.cliff[0] + analog_manager.cliff[1])/2) - ((analog_manager.cliff[2] + analog_manager.cliff[3])/2);
 
-  if (isIMUOrientationValid() && cfg.stop_at_tilt)
+  if (isIMUOrientationValid() && cfg.stop_at_tilt > 0)
   {
     ////////////// Left Tilting Detection ////////////////////
     if (left_tilt > 300 && stat.imu.ax > 1 && stat.imu.ax < 2.5 && left_tilt_flag == false)
     {
       left_tilt_flag = true;
-      runstop_manager.activate_runstop();
     }
     if (left_tilt < 50 && stat.imu.ax < 1 && left_tilt_flag == true)
     {
@@ -521,7 +520,6 @@ void update_tilt_monitor()
     if (right_tilt > 300 && stat.imu.ax > -2.5 && stat.imu.ax < -0.75 && right_tilt_flag == false)
     {
       right_tilt_flag = true;
-      runstop_manager.activate_runstop();
     }
     if (right_tilt < 50 && stat.imu.ax > -1 && right_tilt_flag == true)
     {
@@ -532,7 +530,6 @@ void update_tilt_monitor()
     if (forward_tilt > 300 && stat.imu.ay > 1 && stat.imu.ay < 2.5 && forward_tilt_flag == false)
     {
       forward_tilt_flag = true;
-      runstop_manager.activate_runstop();
     }
     if (forward_tilt < 50 && stat.imu.ay < 1 && forward_tilt_flag == true)
     {
@@ -540,6 +537,10 @@ void update_tilt_monitor()
     }
 
     state_over_tilt_alert=(left_tilt_flag || right_tilt_flag || forward_tilt_flag);
+    if (state_over_tilt_alert && cfg.stop_at_tilt == 1)
+    {
+      runstop_manager.activate_runstop();
+    }
     state_over_tilt_type = (left_tilt_flag ? 0x01 : 0 | right_tilt_flag ? 0x02 : 0 | forward_tilt_flag ? 0x03 :0);
   }
   

--- a/arduino/hello_pimu/Pimu.cpp
+++ b/arduino/hello_pimu/Pimu.cpp
@@ -62,7 +62,9 @@ ChargerManager charger_manager;
 bool state_charger_connected = false;
 bool state_charger_is_charging = false;
 
-
+bool left_tilt_flag = false;
+bool right_tilt_flag = false;
+bool forward_tilt_flag = false;
 
 
 
@@ -493,15 +495,65 @@ void update_current_monitor()
 
 void update_tilt_monitor()
 {
-  if(isIMUOrientationValid() && (abs(stat.imu.pitch)>over_tilt_alert_deg || abs(stat.imu.roll)>over_tilt_alert_deg) && cfg.stop_at_tilt) //over tilt
-      {
-        state_over_tilt_alert=true;
-        runstop_manager.activate_runstop();
-      }
-      else
-      {
-        state_over_tilt_alert=false;
-      }
+  float left_tilt;
+  float right_tilt;
+  float forward_tilt;
+
+
+  left_tilt = analog_manager.cliff[3] - analog_manager.cliff[1];
+  right_tilt = analog_manager.cliff[2] - analog_manager.cliff[0];
+  forward_tilt = ((analog_manager.cliff[0] + analog_manager.cliff[1])/2) - ((analog_manager.cliff[2] + analog_manager.cliff[3])/2);
+
+  // Serial.println(forward_tilt);
+
+  if (isIMUOrientationValid())
+  {
+    /// Left Tilting Detection ////////////////////
+    if (left_tilt > 300 && stat.imu.ax > 1 && stat.imu.ax < 2.5 && left_tilt_flag == false)
+    {
+      left_tilt_flag = true;
+      runstop_manager.activate_runstop();
+    }
+    if (left_tilt < 50 && stat.imu.ax < 1 && left_tilt_flag == true)
+    {
+      left_tilt_flag = false;
+    }
+
+    /// Right Tilting Detection ////////////////////
+    if (right_tilt > 300 && stat.imu.ax > -2.5 && stat.imu.ax < -0.75 && right_tilt_flag == false)
+    {
+      right_tilt_flag = true;
+      runstop_manager.activate_runstop();
+    }
+    if (right_tilt < 50 && stat.imu.ax > -1 && right_tilt_flag == true)
+    {
+      right_tilt_flag = false;
+    }
+
+        /// Forward Tilting Detection ////////////////////
+    if (forward_tilt > 300 && stat.imu.ay > 1 && stat.imu.ay < 2.5 && forward_tilt_flag == false)
+    {
+      forward_tilt_flag = true;
+      runstop_manager.activate_runstop();
+    }
+    if (forward_tilt < 50 && stat.imu.ay < 1 && forward_tilt_flag == true)
+    {
+      forward_tilt_flag = false;
+    }
+
+
+    state_over_tilt_alert=(left_tilt_flag || right_tilt_flag || forward_tilt_flag);
+  }
+  // if(isIMUOrientationValid() && (abs(stat.imu.pitch)>over_tilt_alert_deg || abs(stat.imu.roll)>over_tilt_alert_deg) && cfg.stop_at_tilt) //over tilt
+  //     {
+  //       state_over_tilt_alert=true;
+  //       runstop_manager.activate_runstop();
+  //     }
+  //     else
+  //     {
+  //       state_over_tilt_alert=false;
+  //     }
+  
 }
 ////////////////////////////
 

--- a/arduino/hello_pimu/Pimu.cpp
+++ b/arduino/hello_pimu/Pimu.cpp
@@ -65,6 +65,7 @@ bool state_charger_is_charging = false;
 bool left_tilt_flag = false;
 bool right_tilt_flag = false;
 bool forward_tilt_flag = false;
+uint8_t state_over_tilt_type = 0;
 
 
 
@@ -537,17 +538,10 @@ void update_tilt_monitor()
     {
       forward_tilt_flag = false;
     }
+
     state_over_tilt_alert=(left_tilt_flag || right_tilt_flag || forward_tilt_flag);
+    state_over_tilt_type = (left_tilt_flag ? 0x01 : 0 | right_tilt_flag ? 0x02 : 0 | forward_tilt_flag ? 0x03 :0);
   }
-  // if(isIMUOrientationValid() && (abs(stat.imu.pitch)>over_tilt_alert_deg || abs(stat.imu.roll)>over_tilt_alert_deg) && cfg.stop_at_tilt) //over tilt
-  //     {
-  //       state_over_tilt_alert=true;
-  //       runstop_manager.activate_runstop();
-  //     }
-  //     else
-  //     {
-  //       state_over_tilt_alert=false;
-  //     }
   
 }
 ////////////////////////////
@@ -611,6 +605,10 @@ void update_status()
   stat.state= state_over_tilt_alert ? stat.state|STATE_OVER_TILT_ALERT : stat.state;
   stat.state = trace_manager.trace_on ?     stat.state | STATE_IS_TRACE_ON: stat.state;
   stat.state= state_charger_is_charging ? stat.state|STATE_IS_CHARGER_CHARGING : stat.state;
+
+  stat.over_tilt_type = state_over_tilt_type;
+
+
   memcpy((uint8_t *) (&stat_out),(uint8_t *) (&stat),sizeof(Pimu_Status));
 
   if(TRACE_TYPE==TRACE_TYPE_DEBUG)

--- a/arduino/hello_pimu/Pimu.cpp
+++ b/arduino/hello_pimu/Pimu.cpp
@@ -499,16 +499,13 @@ void update_tilt_monitor()
   float right_tilt;
   float forward_tilt;
 
-
   left_tilt = analog_manager.cliff[3] - analog_manager.cliff[1];
   right_tilt = analog_manager.cliff[2] - analog_manager.cliff[0];
   forward_tilt = ((analog_manager.cliff[0] + analog_manager.cliff[1])/2) - ((analog_manager.cliff[2] + analog_manager.cliff[3])/2);
 
-  // Serial.println(forward_tilt);
-
-  if (isIMUOrientationValid())
+  if (isIMUOrientationValid() && cfg.stop_at_tilt)
   {
-    /// Left Tilting Detection ////////////////////
+    ////////////// Left Tilting Detection ////////////////////
     if (left_tilt > 300 && stat.imu.ax > 1 && stat.imu.ax < 2.5 && left_tilt_flag == false)
     {
       left_tilt_flag = true;
@@ -519,7 +516,7 @@ void update_tilt_monitor()
       left_tilt_flag = false;
     }
 
-    /// Right Tilting Detection ////////////////////
+    /////////////////// Right Tilting Detection ////////////////////
     if (right_tilt > 300 && stat.imu.ax > -2.5 && stat.imu.ax < -0.75 && right_tilt_flag == false)
     {
       right_tilt_flag = true;
@@ -530,7 +527,7 @@ void update_tilt_monitor()
       right_tilt_flag = false;
     }
 
-        /// Forward Tilting Detection ////////////////////
+    //////// Forward Tilting Detection //////////////////////////////////
     if (forward_tilt > 300 && stat.imu.ay > 1 && stat.imu.ay < 2.5 && forward_tilt_flag == false)
     {
       forward_tilt_flag = true;
@@ -540,8 +537,6 @@ void update_tilt_monitor()
     {
       forward_tilt_flag = false;
     }
-
-
     state_over_tilt_alert=(left_tilt_flag || right_tilt_flag || forward_tilt_flag);
   }
   // if(isIMUOrientationValid() && (abs(stat.imu.pitch)>over_tilt_alert_deg || abs(stat.imu.roll)>over_tilt_alert_deg) && cfg.stop_at_tilt) //over tilt


### PR DESCRIPTION
This PR introduces a tilt detection safety feature at the firmware level. It monitors IMU orientation and cliff sensor differentials to determine if the robot is at risk of falling over. If so, it can activate runstop to prevent motion (`stop_at_tilt` parameter can be set to True to enable this behavior). It also reports the type of tilt detected to the high level software, enabling users to build this safety feature into their own application.