### PR TITLE
Traj Control Stuttering issuses 

### DIFF
--- a/arduino/hello_stepper/AnalogManager.cpp
+++ b/arduino/hello_stepper/AnalogManager.cpp
@@ -27,7 +27,7 @@ AnalogManager::AnalogManager(){
   voltage_LPFa = 1.0; 
   voltage_LPFb = 0.0;
   first_filter=1;
-  first_read_done=0;
+  adc_results_ready=0;
   first_config=1;
   adc_input_id=0;
 
@@ -52,16 +52,17 @@ void AnalogManager::update_config(Gains * cfg_new, Gains * cfg_old)
 
 void AnalogManager::step()
 {
-  if (!first_read_done)
+  if (!adc_results_ready)
     return;
 
-  if (first_filter)
-  {
-    voltage = adcResult[IDX_ANA_V_BATT];
-    first_filter=false;
-  }
+  // if (first_filter)
+  // {
+  //   voltage = adcResult[IDX_ANA_V_BATT];
+  //   first_filter=false;
+  // }
 
-  voltage = voltage * voltage_LPFa +  voltage_LPFb* adcResult[IDX_ANA_V_BATT];
+  // voltage = voltage * voltage_LPFa +  voltage_LPFb* adcResult[IDX_ANA_V_BATT];
+  voltage = adcResult[IDX_ANA_V_BATT];
 }
 
 void AnalogManager::setupADC()
@@ -76,7 +77,7 @@ void AnalogManager::setupADC()
                    ADC_CTRLB_FREERUN;                // Set the ADC to free run
  
   while(ADC->STATUS.bit.SYNCBUSY);                   // Wait for synchronization 
-  NVIC_SetPriority(ADC_IRQn, 0);    // Set the Nested Vector Interrupt Controller (NVIC) priority for the ADC to 0 (highest)
+  NVIC_SetPriority(ADC_IRQn, 2);    // Set the Nested Vector Interrupt Controller (NVIC) priority for the ADC to 0 (highest)
   NVIC_EnableIRQ(ADC_IRQn);         // Connect the ADC to Nested Vector Interrupt Controller (NVIC)
   ADC->INTENSET.reg = ADC_INTENSET_RESRDY;           // Generate interrupt on result ready (RESRDY)
   ADC->CTRLA.bit.ENABLE = 1;                         // Enable the ADC
@@ -99,7 +100,7 @@ void ADC_Handler()
     if (analog_manager.adc_input_id==NUM_ADC_INPUTS)
     {
       analog_manager.adc_input_id=0;
-      analog_manager.first_read_done=1;
+      analog_manager.adc_results_ready=1;
     }
     ADC->CTRLA.bit.ENABLE = 0;                     // Disable the ADC
     while(ADC->STATUS.bit.SYNCBUSY);               // Wait for synchronization

--- a/arduino/hello_stepper/AnalogManager.cpp
+++ b/arduino/hello_stepper/AnalogManager.cpp
@@ -54,14 +54,6 @@ void AnalogManager::step()
 {
   if (!adc_results_ready)
     return;
-
-  // if (first_filter)
-  // {
-  //   voltage = adcResult[IDX_ANA_V_BATT];
-  //   first_filter=false;
-  // }
-
-  // voltage = voltage * voltage_LPFa +  voltage_LPFb* adcResult[IDX_ANA_V_BATT];
   voltage = adcResult[IDX_ANA_V_BATT];
 }
 

--- a/arduino/hello_stepper/AnalogManager.h
+++ b/arduino/hello_stepper/AnalogManager.h
@@ -26,11 +26,11 @@ class AnalogManager {
 
     float voltage_LPFa; 
     float voltage_LPFb;
-    float voltage;
+    uint16_t voltage;
     volatile uint16_t adcResult[NUM_ADC_INPUTS] = {};         // ADC results buffer
     uint8_t mux_map[NUM_ADC_INPUTS];
     uint8_t adc_input_id;
-    bool first_read_done;
+    volatile bool adc_results_ready;
   private:
     bool first_filter;
     bool first_config;

--- a/arduino/hello_stepper/Common.h
+++ b/arduino/hello_stepper/Common.h
@@ -41,7 +41,8 @@
 // Version 0.7.3: Issue with tag system, trying version bump
 // Version 0.7.4: Put arm in drive-off mode when in runstop
 // Version 0.7.5: Bug fix with 0.7.4 not allowing motors to calibrate
-#define FIRMWARE_VERSION_HR "Stepper.v0.7.5p5"
+// Version 0.7.6: Bug fix with 0.7.5 traj control enduces stutter due to the priority of adc interupts and the floating point math assoicated with it
+#define FIRMWARE_VERSION_HR "Stepper.v0.7.6p5"
 
 /////////////////////////////////////////////////////////////////
 

--- a/arduino/hello_stepper/HelloController.cpp
+++ b/arduino/hello_stepper/HelloController.cpp
@@ -184,16 +184,16 @@ float get_voltage_calibrated(float raw)
 //goes down for a given current
 //Only works for VARIANT_3 and later boards
 
-float current_to_effort_v_norm(float x)
-{
-    float e=current_to_effort(x);
-   if (BOARD_VARIANT>=3 && voltage_calibrated!=0)
-   {
-    return max(-255,min(255,e*voltage_calibrated/NOMINAL_BUS_VOLTAGE));
-   }
-   else
-    return e;
-}
+// float current_to_effort_v_norm(float x)
+// {
+//     float e=current_to_effort(x);
+//    if (BOARD_VARIANT>=3 && voltage_calibrated!=0)
+//    {
+//     return max(-255,min(255,e*voltage_calibrated/NOMINAL_BUS_VOLTAGE));
+//    }
+//    else
+//     return e;
+// }
 
 float effort_to_current(float e)
 {
@@ -555,7 +555,8 @@ void update_status()
   if (BOARD_VARIANT >= 3)
   {
     stat.voltage=analog_manager.voltage;
-    voltage_calibrated=get_voltage_calibrated(stat.voltage);
+    // stat.voltage = 0;
+    // voltage_calibrated=get_voltage_calibrated(stat.voltage);
   }
   else
   {
@@ -905,8 +906,10 @@ void stepHelloController()
         cmd.stiffness=cmd_in.stiffness;
         cmd.i_contact_pos =cmd_in.i_contact_pos;
         cmd.i_contact_neg =cmd_in.i_contact_neg;
-        g_eff_pos=current_to_effort_v_norm(abs(cmd.i_contact_pos));
-        g_eff_neg=current_to_effort_v_norm(-1*abs(cmd.i_contact_neg));
+        g_eff_pos=current_to_effort(abs(cmd.i_contact_pos));
+        g_eff_neg=current_to_effort(-1*abs(cmd.i_contact_neg));
+        // g_eff_pos=current_to_effort_v_norm(abs(cmd.i_contact_pos));
+        // g_eff_neg=current_to_effort_v_norm(-1*abs(cmd.i_contact_neg));
       
         //If mode has changed manage smooth switchover
         if (cmd.mode!=mode_last)
@@ -1437,8 +1440,8 @@ void setupMGInterrupts() {  // configure the controller interrupt
 //Jitter on commutation seems to be OK for performance
 
 
-  NVIC_SetPriority(TC4_IRQn, 1);      //1        see https://github.com/arduino/ArduinoCore-samd/blob/master/cores/arduino/cortex_handlers.c#L84
-  NVIC_SetPriority(TC5_IRQn, 2);      //2        
+  NVIC_SetPriority(TC4_IRQn, 0);      //1        see https://github.com/arduino/ArduinoCore-samd/blob/master/cores/arduino/cortex_handlers.c#L84
+  NVIC_SetPriority(TC5_IRQn, 1);      //2        
 
   // Enable InterruptVector
   NVIC_EnableIRQ(TC4_IRQn);

--- a/arduino/hello_stepper/HelloController.cpp
+++ b/arduino/hello_stepper/HelloController.cpp
@@ -179,22 +179,6 @@ float get_voltage_calibrated(float raw)
  return (raw*RAW_TO_VOLTAGE)-0.3; //0.3 is needed to account for leakage current of TVS
 }
 
-//This returns an effort value (-255 to 255) that is normalized by the bus voltage
-//such that as the bus voltage drops, the estimate of effort "force" applied to the outside world
-//goes down for a given current
-//Only works for VARIANT_3 and later boards
-
-// float current_to_effort_v_norm(float x)
-// {
-//     float e=current_to_effort(x);
-//    if (BOARD_VARIANT>=3 && voltage_calibrated!=0)
-//    {
-//     return max(-255,min(255,e*voltage_calibrated/NOMINAL_BUS_VOLTAGE));
-//    }
-//    else
-//     return e;
-// }
-
 float effort_to_current(float e)
 {
   return (e*k_e2c);
@@ -908,8 +892,6 @@ void stepHelloController()
         cmd.i_contact_neg =cmd_in.i_contact_neg;
         g_eff_pos=current_to_effort(abs(cmd.i_contact_pos));
         g_eff_neg=current_to_effort(-1*abs(cmd.i_contact_neg));
-        // g_eff_pos=current_to_effort_v_norm(abs(cmd.i_contact_pos));
-        // g_eff_neg=current_to_effort_v_norm(-1*abs(cmd.i_contact_neg));
       
         //If mode has changed manage smooth switchover
         if (cmd.mode!=mode_last)
@@ -1440,8 +1422,8 @@ void setupMGInterrupts() {  // configure the controller interrupt
 //Jitter on commutation seems to be OK for performance
 
 
-  NVIC_SetPriority(TC4_IRQn, 0);      //1        see https://github.com/arduino/ArduinoCore-samd/blob/master/cores/arduino/cortex_handlers.c#L84
-  NVIC_SetPriority(TC5_IRQn, 1);      //2        
+  NVIC_SetPriority(TC4_IRQn, 0);      //0        see https://github.com/arduino/ArduinoCore-samd/blob/master/cores/arduino/cortex_handlers.c#L84
+  NVIC_SetPriority(TC5_IRQn, 1);      //1        
 
   // Enable InterruptVector
   NVIC_EnableIRQ(TC4_IRQn);


### PR DESCRIPTION
@hello-binit noted that the Traj control caused the stepper motors to stutter. This issue was caused by multiple things
1) ADC interrupt priority set wrong
2) ADC voltage low pass voltage calculation causing slowdowns
3) Gaurded contacts normalization based on voltage